### PR TITLE
fix: page navigation on explore

### DIFF
--- a/Client/src/routes/explore/new-works/+page.svelte
+++ b/Client/src/routes/explore/new-works/+page.svelte
@@ -19,7 +19,7 @@
 		loading = true;
 		$page.url.searchParams.set("page", `${pageNum}`);
 		const response = await getReq<Paginate<Work>>(
-			`/explore/new-works?filter=${$app.filter}?page=${currPage}&per=${perPage}`
+			`/explore/new-works?filter=${$app.filter}&page=${currPage}&per=${perPage}`
 		);
 		if ((response as ResponseError).error) {
 			const error = response as ResponseError;


### PR DESCRIPTION
addresses a typo in the GET request URL that prevented the API from seeing the appropriate content filter.

closes #15