### PR TITLE
fix: pagination on explore

### DIFF
--- a/Client/src/routes/explore/new-works/+page.svelte
+++ b/Client/src/routes/explore/new-works/+page.svelte
@@ -12,12 +12,12 @@
 	export let data: Paginate<Work>;
 	let loading = false;
 
-	$: currPage = +($page.url.searchParams.get("page") ?? "1");
-	$: perPage = +($page.url.searchParams.get("per") ?? "24");
+	let currPage = +($page.url.searchParams.get("page") ?? "1");
+	let perPage = +($page.url.searchParams.get("per") ?? "24");
 
 	async function fetchPage(pageNum: number) {
 		loading = true;
-		$page.url.searchParams.set("page", `${pageNum}`);
+		currPage = pageNum;
 		const response = await getReq<Paginate<Work>>(
 			`/explore/new-works?filter=${$app.filter}&page=${currPage}&per=${perPage}`
 		);


### PR DESCRIPTION
fixes an issue where pages aren't changing because `currPage` is never actually updated with its most up-to-date value